### PR TITLE
Increase wait time for services and setup scripts for slower machines

### DIFF
--- a/data_service/__main__.py
+++ b/data_service/__main__.py
@@ -12,7 +12,7 @@ parser.add_argument('-d', '--docker', action='store_true', help="run in Docker c
 args = parser.parse_args()
 verbose = args.verbose
 docker = args.docker
-mysql_delay = 40
+mysql_delay = 60
 
 logging.basicConfig(
     level=logging.DEBUG if verbose else logging.INFO,

--- a/data_worker/__main__.py
+++ b/data_worker/__main__.py
@@ -13,15 +13,15 @@ args = parser.parse_args()
 verbose = args.verbose
 docker = args.docker
 
-mysql_delay = 20
+rabbit_delay = 20
 
 logging.basicConfig(
     level=logging.DEBUG if verbose else logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s [%(name)s]"
 )
 
-logging.debug(f"Waiting for MySQL to start up, sleeping for {mysql_delay} seconds...")
-time.sleep(mysql_delay)
+logging.debug(f"Waiting for RabbitMQ to start up, sleeping for {rabbit_delay} seconds...")
+time.sleep(rabbit_delay)
 
 dw = DataWorker(docker)
 

--- a/deployments/start-deps.sh
+++ b/deployments/start-deps.sh
@@ -15,7 +15,7 @@ docker-compose -f "$SCRIPT_DIR/docker-compose-test.yml" up --build --detach --re
 echo "Waiting for MySQL to start up..."
 iter=0
 # shellcheck disable=SC2154
-while [ $iter -lt 30 ] && ! MYSQL_PWD=$MYSQL_ROOT_PASS mysqladmin ping -h"127.0.0.1" --port "3306" -u "root" --silent; do
+while [ $iter -lt 60 ] && ! MYSQL_PWD=$MYSQL_ROOT_PASS mysqladmin ping -h"127.0.0.1" --port "3306" -u "root" --silent; do
     sleep 1
     iter=$((iter + 1))
 done

--- a/deployments/start-prod.sh
+++ b/deployments/start-prod.sh
@@ -15,7 +15,7 @@ docker-compose -f "$SCRIPT_DIR/docker-compose-prod.yml" up --build --detach --re
 echo "Waiting for MySQL to start up..."
 iter=0
 # shellcheck disable=SC2154
-while [ $iter -lt 30 ] && ! MYSQL_PWD=$MYSQL_ROOT_PASS mysqladmin ping -h"127.0.0.1" --port "3306" -u "root" --silent; do
+while [ $iter -lt 60 ] && ! MYSQL_PWD=$MYSQL_ROOT_PASS mysqladmin ping -h"127.0.0.1" --port "3306" -u "root" --silent; do
     sleep 1
     iter=$((iter + 1))
 done

--- a/moderator_service/__main__.py
+++ b/moderator_service/__main__.py
@@ -13,7 +13,7 @@ args = parser.parse_args()
 verbose = args.verbose
 docker = args.docker
 
-mysql_delay = 40
+mysql_delay = 60
 
 logging.basicConfig(
     level=logging.DEBUG if verbose else logging.INFO,

--- a/moderator_worker/__main__.py
+++ b/moderator_worker/__main__.py
@@ -12,15 +12,15 @@ parser.add_argument('-d', '--docker', action='store_true', help="run in Docker c
 args = parser.parse_args()
 verbose = args.verbose
 docker = args.docker
-mysql_delay = 20
+rabbit_delay = 20
 
 logging.basicConfig(
     level=logging.DEBUG if verbose else logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s [%(name)s]"
 )
 
-logging.debug(f"Waiting for MySQL to start up, sleeping for {mysql_delay} seconds...")
-time.sleep(mysql_delay)
+logging.debug(f"Waiting for RabbitMQ to start up, sleeping for {rabbit_delay} seconds...")
+time.sleep(rabbit_delay)
 
 mw = ModeratorWorker(docker)
 


### PR DESCRIPTION
This PR fixes a bug where setting up AWB for the first time fails on windigo because the time waiting for MySQL to finish initializing was not long enough. Extended wait time for services and scripts on both MySQL and RabbitMQ startup.