### PR TITLE
Investigate and Fix Nack Exceptions

### DIFF
--- a/moderator_service/__init__.py
+++ b/moderator_service/__init__.py
@@ -108,4 +108,5 @@ class ModeratorService:
             )
             enqueue_task = asyncio.create_task(exchange.publish(msg, routing_key=self.queue_name))
             enqueue_tasks.append(enqueue_task)
-        await asyncio.gather(*enqueue_tasks)
+        # TODO: ignore publishing errors
+        await asyncio.gather(*enqueue_tasks, return_exceptions=True)


### PR DESCRIPTION
Occasionally, Moderator Service will throw AIOMRQ Delivery Errors citing a Nack’d object.

Most likely due to deduplication module. According to [aio-pika docs, publisher confirms](https://aio-pika.readthedocs.io/en/latest/_modules/aio_pika/exchange.html#Exchange.publish) is used for message delivery and will return a Nack error when deduplication rejects a message.

Silenced Nack errors for now, might come up with a more robust approach later.