### PR TITLE
Fix RabbitMQ message delivery timeouts

### DIFF
--- a/deployments/docker-compose-prod.yml
+++ b/deployments/docker-compose-prod.yml
@@ -37,6 +37,7 @@ services:
       - rabbitmq:/var/lib/rabbitmq
       - ./rabbit/enabled_plugins:/etc/rabbitmq/enabled_plugins
       - ./rabbit/plugins:/usr/lib/rabbitmq/plugins
+      - ./rabbit/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     networks:
       - awb
 

--- a/deployments/rabbit/rabbitmq.conf
+++ b/deployments/rabbit/rabbitmq.conf
@@ -1,0 +1,2 @@
+# Set message delivery acknowledgement to timeout in 2 hours instead of 30 minutes
+consumer_timeout = 7200000


### PR DESCRIPTION
If a submission fails to be sourced within the timeout, SourceCommentAny fails to remove the submission.

If message fails to be acknowledged by 1800000 ms, RabbitMQ times out and the entire task is cancelled.

Adjusted timeout to be longer (2 hours) by supplying a `rabbitmq.conf` file.