### PR TITLE
Evaluate AutoMod-filtered submissions

### DIFF
--- a/moderator_service/__init__.py
+++ b/moderator_service/__init__.py
@@ -42,11 +42,20 @@ class ModeratorService:
                         await self.update_settings()
                         await self._enqueue_submissions_to_moderate(exchange)
                     except (RequestException, ResponseException) as e:
-                        self.log.error("Failed to update settings from reddit: %s", e)
+                        self.log.error("Failed to update attributes from reddit: %s", e)
                     except Exception as e:
                         self.log.exception("Unknown error: %s", e)
                     finally:
                         await asyncio.sleep(60)
+
+    async def update_filtered_submissions(self):
+        async with Reddit(**self.reddit_auth, timeout=30) as reddit:
+            mod_subreddit = await reddit.subreddit("mod")
+            return (
+                submission.id
+                async for submission in mod_subreddit.mod.modqueue(limit=None, only="submissions")
+                if submission.banned_by == "AutoModerator"
+            )
 
     async def update_settings(self):
         async with async_database_ctx(self.mysql_auth) as db:
@@ -92,6 +101,8 @@ class ModeratorService:
         return None
 
     async def _enqueue_submissions_to_moderate(self, exchange):
+        # Refresh filtered submissions
+        filtered_submissions = await self.update_filtered_submissions()
         # TODO: fix window to 48 hours for now until posting frequency increases
         after_utc = int(time.time()) - 172800
         async with async_database_ctx(self.mysql_auth) as db:
@@ -99,8 +110,9 @@ class ModeratorService:
             submissions = await db.fetchall()
         enqueue_tasks = []
         for submission in submissions:
-            msg_body = submission['id'].encode()
-            dedup_header = md5(msg_body).hexdigest()
+            msg_json = json.dumps({"id": submission['id'], "filtered": (submission['id'] in filtered_submissions)})
+            msg_body = msg_json.encode()
+            dedup_header = md5(submission['id'].encode()).hexdigest()
             msg = Message(
                 msg_body,
                 delivery_mode=DeliveryMode.PERSISTENT,


### PR DESCRIPTION
A submission is considered “removed” if and only if the `banned_by` field is not null. However, AutoMod has a unique operation where it can filter the submission given a certain condition: it acts as if it removed the submission, but it appears in the mod queue for manual review. In this case, AWB should still evaluate the submission as if it wasn’t removed.

Added an extra check upon refreshing to see if submission is in moderation queue and was removed by AutoMod. This will be used as the condition for a filtered submission.