### PR TITLE
Exclude submissions made by certain users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![](https://raw.githubusercontent.com/LZ58840/AnimewallpaperBot/main/banner.png)
-# AnimewallpaperBot v2.0
+# AnimewallpaperBot v2.0.1
 A specialized moderation bot for /r/Animewallpaper and possibly some other wallpaper subreddits I moderate.
 
 ## Features

--- a/moderator_worker/__init__.py
+++ b/moderator_worker/__init__.py
@@ -87,7 +87,7 @@ class ModeratorWorker:
                 await db.execute('SELECT settings FROM subreddits WHERE name=%s', submission.subreddit.display_name)
                 subreddit = await db.fetchone()
                 subreddit_settings = json.loads(subreddit['settings'])
-                if not subreddit_settings["enabled"]:
+                if not subreddit_settings["enabled"] or submission.author.name in subreddit_settings['except_authors']:
                     response.status = ModeratorWorkerStatus.SKIPPED
                     return response
                 # https://stackoverflow.com/a/67695802

--- a/utils.py
+++ b/utils.py
@@ -92,6 +92,7 @@ def get_default_settings():
     return {
         'enabled': False,
         'flairs': {},
+        'except_authors': [],
         'ResolutionAny': {'enabled': False},
         'ResolutionMismatch': {'enabled': False},
         'ResolutionBad': {


### PR DESCRIPTION
Non wallpaper posts like announcements and weekly scheduled threads keep getting removed because of SourceCommentAny. Those kinds of posts are only made by certain users (e.g. AutoModerator) and should be exempt from normal moderating.

In ModWorker, added a setting such that if a submission comes from a certain user, skip it.