### PR TITLE
Add Backoff adjustment in DataService and ModeratorService

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,9 @@ from asyncio import AbstractEventLoop, get_running_loop
 from logging import Handler, NOTSET, LogRecord
 from discord_webhook import DiscordWebhook, AsyncDiscordWebhook, DiscordEmbed
 
+MIN_BACKOFF = 60
+MAX_BACKOFF = 3600
+
 dotenv_path = Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".env"))
 if not load_dotenv(dotenv_path=dotenv_path):
     print("Couldn't load the configuration file. "


### PR DESCRIPTION
Access to Discord results in code 429.

Excessive usage of the Discord logging module (see https://github.com/LZ58840/AnimewallpaperBot/pull/9) causes extreme rate limiting to take effect. Errors occurred due to reddit outage.

Introduced increasing and decreasing backoff for both ModeratorService and DataService depending on reddit API issues.