### PR TITLE
Refactor time delta calculation in RateLimitAny

### DIFF
--- a/moderator_worker/rules.py
+++ b/moderator_worker/rules.py
@@ -293,7 +293,9 @@ class RateLimitAny(Rule):
             return
         interval_seconds = interval_hours * 3600
         async with async_database_ctx(self.mysql_auth) as db:
-            await db.execute(f"SELECT s.id, s.created_utc, l.created_utc-s.created_utc AS seconds_since "
+            await db.execute(f"SELECT s.id, s.created_utc, "
+                             f"TIMESTAMPDIFF(hour,FROM_UNIXTIME(s.created_utc),FROM_UNIXTIME(l.created_utc)) AS hours_since,"
+                             f"TIMESTAMPDIFF(minute,FROM_UNIXTIME(s.created_utc),FROM_UNIXTIME(l.created_utc)) AS minutes_since "
                              f"FROM submissions s, (SELECT id, author, created_utc, subreddit "
                              f"FROM submissions WHERE id=%s) l "
                              f"WHERE s.author=l.author AND s.subreddit=l.subreddit AND s.id!=l.id "
@@ -307,7 +309,7 @@ class RateLimitAny(Rule):
             active_str = [
                 self.active_template.format(
                     submission_id=row["id"],
-                    dur=self.format_duration(row["seconds_since"])
+                    dur=self.format_duration(row["hours_since"], row["minutes_since"])
                 ) for row in rows
             ]
             next_str = self.next_template.format(
@@ -320,15 +322,13 @@ class RateLimitAny(Rule):
                     + next_str)
 
     @staticmethod
-    def format_duration(sec_since: int):
-        total_minutes = sec_since // 60
-        duration_hour = total_minutes // 60
-        duration_minute = total_minutes % 60
-        if duration_minute == duration_hour == 0:
+    def format_duration(hours_since, minutes_since):
+        if hours_since == 0 and minutes_since == 0:
             return 'just now'
-        hour_str = (f'{str(duration_hour)} hours' if duration_hour > 1 else f'1 hour' if duration_hour == 1 else '')
+        duration_minute = minutes_since % 60
+        hour_str = (f'{hours_since} hours' if hours_since > 1 else f'1 hour' if hours_since == 1 else '')
         minute_str = (f', {str(duration_minute)} minutes' if duration_minute > 1 else f', 1 minute' if duration_minute == 1 else '')
-        return (hour_str + minute_str + " prior").lstrip(", ")
+        return (hour_str + minute_str + " ago").lstrip(", ")
 
 
 class RuleBook:


### PR DESCRIPTION
If two adjacent submissions by the same user were posted at or around the same time and the Rate Limit is reached, the time since between the two submissions sometimes reads “59 mins prior” instead of “just now”.

Refactor the time delta conversion using MySQL datetime in attempt to prevent the above formatting bug.