### PR TITLE
Clear archived submissions

### DIFF
--- a/deployments/setup.sql
+++ b/deployments/setup.sql
@@ -26,3 +26,9 @@ CREATE TABLE IF NOT EXISTS images (
     UNIQUE KEY (submission_id, url),
     FOREIGN KEY (submission_id) REFERENCES submissions(id) ON DELETE CASCADE
 );
+CREATE EVENT IF NOT EXISTS
+    ClearArchivedSubmissions
+ON SCHEDULE EVERY 1 DAY
+DO
+    DELETE FROM submissions
+    WHERE TIMESTAMPDIFF(month, FROM_UNIXTIME(created_utc), NOW()) > 6;


### PR DESCRIPTION
To make way for the new Repost Checking module (see [Repost Checking](https://www.notion.so/Repost-Checking-64746075be2e4a669d4cd11761f6daa7)), image data will need to be stored in the database itself. This will obviously take up a lot more space, so a time delta cap has to be implemented to delete submissions that are old enough.

Made a Stored Procedure in MySQL database to purge submission info after [6 months].