### PR TITLE
Fix lingering check for SourceCommentAny

### DIFF
--- a/moderator_worker/rules.py
+++ b/moderator_worker/rules.py
@@ -264,6 +264,12 @@ class SourceCommentAny(Rule):
                 await wait_for(removal_flag.wait(), timeout=60)
             except TimeoutError:
                 await submission.load()
+                # Check if submission was manually moderated and cancel if yes
+                removed = submission.banned_by is not None and submission.banned_by != "AutoModerator"
+                deleted = submission.removed_by_category == "deleted"
+                approved = submission.approved_by is not None
+                if any((removed, deleted, approved)):
+                    return
                 comments = await submission.comments()
                 for comment in comments:
                     if comment.author.name == submission.author.name:


### PR DESCRIPTION
If a manual action is performed on a submission with no source comment present, AWB still tries to remove the submission with comment.

While checking for source, AWB does not keep track of current submission status.

Every time Async thread wakes from sleep, SourceCommentAny will first check if submission was manually moderated. If so, cancel the check for source comment.