### PR TITLE
Fix crosspost checking criteria

### DIFF
--- a/data_worker/__init__.py
+++ b/data_worker/__init__.py
@@ -105,8 +105,8 @@ class DataWorker:
             )
         elif (match := re.match(REDDIT_REGEX_STR, url)) is not None:
             # Submission is x-post, load original submission instead
-            gallery_id = match.group('gallery_id')
-            if gallery_id != submission.id:
+            gallery_id: str | None = match.group('gallery_id')
+            if gallery_id is not None and gallery_id != submission.id:
                 async with Reddit(**self.reddit_auth, timeout=30) as reddit:
                     submission = await reddit.submission(gallery_id)
             return await extract_from_reddit_url(


### PR DESCRIPTION
Submissions can’t get processed because the crosspost checking criteria in #20 does not account for non-existent gallery IDs. 

Added extra condition that gallery IDs should not be null.