### PR TITLE
Fix SourceCommentAny removing good submissions after long outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![](https://raw.githubusercontent.com/LZ58840/AnimewallpaperBot/main/banner.png)
-# AnimewallpaperBot v2.1.0
+# AnimewallpaperBot v2.1.1
 A specialized moderation bot for /r/Animewallpaper and possibly some other wallpaper subreddits I moderate.
 
 ## Features

--- a/moderator_worker/rules.py
+++ b/moderator_worker/rules.py
@@ -259,7 +259,7 @@ class SourceCommentAny(Rule):
             return
         deadline_utc = submission.created_utc + 3600 * timeout_hrs
         await submission.comments.replace_more(limit=None)
-        while deadline_utc > time.time():
+        while True:
             try:
                 await wait_for(removal_flag.wait(), timeout=60)
             except TimeoutError:
@@ -274,6 +274,8 @@ class SourceCommentAny(Rule):
                 for comment in comments:
                     if comment.author.name == submission.author.name:
                         return
+                if deadline_utc <= time.time():
+                    break
                 continue
             else:
                 return


### PR DESCRIPTION
If AWB starts after a while without collecting new submissions, SourceCommentAny removes the new submissions even after they have been sourced.

If the source check occurs past the time limit, no matter if the submission has a source comment or not, the submission will be removed.

The submission should be checked at least once by using a pseudo do-while loop.